### PR TITLE
typo: AntD -> antd

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ $ npm run trans
 ## Getting Start
 
 * [Getting Start](docs/getting-start.md)
-* [Understanding AntD i18n](docs/understanding-antd-i18n.md)
+* [Understanding antd i18n](docs/understanding-antd-i18n.md)
 * [React Intl Examples](docs/react-intl-corner-cases.md)


### PR DESCRIPTION
AntD 是 [FAQ - Ant Design](https://ant.design/docs/react/faq-cn#%E5%A6%82%E4%BD%95%E6%AD%A3%E7%A1%AE%E7%9A%84%E6%8B%BC%E5%86%99-Ant-Design%EF%BC%9F) 中提到的典型的错误拼写